### PR TITLE
(fix) Fix client.register cache lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,207 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.1] - 2020-07-14
+
+### Changed
+
+- `Avro` serialization for complex `faust` records that contains nested `records`, `Mapping` or `Sequences fixed` [#59](https://github.com/marcosschroh/python-schema-registry-client/issues/59)
+
+## [1.4.0] - 2020-05-07
+
+### Added
+
+- timeout and pool_limits added to client
+
+## [1.3.2] - 2020-05-06
+
+### Fixed
+
+- Allow SchemaRegistryClient to be picklable fixed #24
+
+## [1.3.1] - 2020-05-03
+
+### Changed
+
+- `requests` library has been replaced with `httpx`
+
+## [1.3.0] - 2020-04-25
+
+### Added
+
+- new properties added to AvroSchema: raw_schema, flat_schema and expanded_schema
+- documentation updated
+
+### Fixed
+
+## [1.2.10] - 2020-04-20
+
+- bad import check fixed causing faust crash
+
+### Fixed
+
+## [1.2.9] - 2020-04-20
+
+- fixed `Importing MessageSerializer` without Faust is Broken [#47](https://github.com/marcosschroh/python-schema-registry-client/issues/47)
+
+### Fixed
+
+## [1.2.8] - 2020-04-18
+
+- fix Base URL was overwritten [#46](https://github.com/marcosschroh/python-schema-registry-client/issues/46)
+
+### Changed
+
+## [1.2.7] - 2020-03-29
+
+- `faust serializer` updated in order to be compatible with latest Faust version
+
+### Fixed
+
+## [1.2.6] - 2020-03-13
+
+- Incorrect message on get_subjects fixed
+
+### Changed
+
+## [1.2.5] - 2020-02-19
+
+- is_key was removed from serializer, meaning that the subject itself will have to express wheter the schema is key or not. Related to [#40](https://github.com/marcosschroh/python-schema-registry-client/issues/40)
+- Requirements updated to latest versions: fastavro and requests
+
+### Changed
+
+## [1.2.4] - 2019-11-16
+
+- Faust requirement updated to <= 1.9.0
+
+### Fixed
+
+## [1.2.3] - 2019-11-02
+
+- fix force `fastavro` to parse always the schemas in order to avoid errors when a process B get the schema from the server that was previously processed by process A.
+
+### Changed
+
+## [1.2.2] - 2019-10-26
+
+- requirements updated
+
+### Changed
+
+## [1.2.1] - 2019-07-23
+
+- Typing added (mypy)
+
+### Added
+
+## [1.2.0] - 2019-07-22
+
+- Missing endpoints added:
+  - GET  /subjects
+  - GET /subjects/{subject}/versions
+  - DELETE /subjects/{subject}/versions/{version}
+
+### Added
+
+## [1.1.0] - 2019-07-19
+
+- Urls manager added to have more control over which endpoint the client is using
+
+### Added
+
+## [1.0.0] - 2019-07-17
+
+- Production ready
+- Move to FastAvro
+- Dependency `avro-python3` removed
+- Support for `logicalTypes` added
+- `AvroSchema` class added to manage schema parse and hasing
+- Tests added
+- Faker lib added to create fixtures
+- Documentation updated
+
+### Fixed
+
+## [0.3.1] - 2019-07-17
+
+- Error mapping proxy fixed when try to register a schema that contains `logicalTypes`
+
+### Added
+
+## [0.3.0] - 2019-07-11
+
+- Faust Serializer has been added
+- Optional Faust requirement added
+
+### Changed
+
+## [0.2.5] - 2019-06-10
+
+- Documentation about `MessageSerializer` and `Faust` Integration updated
+
+### Changed
+
+## [0.2.4] - 2019-06-05
+
+- Missing Compatibility levels added.
+- `ClienError` added to the documentation
+- Tests refactored
+
+### Fixed
+
+## [0.2.3] - 2019-05-31
+
+- HTTP code and `server_traceback` added to the `ClientError` when Schema Server returns a not success when a schema compatibility check is requested.
+
+### Fixed
+
+## [0.2.2] - 2019-05-29
+
+- Missing tests added.
+- Bug in register fixed.
+
+### Changed
+
+## [0.2.1] - 2019-05-27
+
+- Documentation updated.
+- Missing Python syntax highlighted added.
+
+### Added
+
+## [0.2.0] - 2019-05-23
+
+- Now all the tests are run against a `Schema Registry Server` and not a mock server. This allows us to be aware of when the server changes. The requirements to run the tests are Docker and `Docker Compose`
+
+### Changed
+
+## [0.1.1] - 2019-05-22
+
+- Http `Client` now is a subclass of `request.Session`
+
+### Added
+
+## [0.1.0] - 2019-05-22
+
+- Now is possible to inisialize SchemaRegistryClient with custom headers. This headers will be included on every requests.
+
+### Changed
+
+## [0.0.3] - 2019-05-22
+
+- small twaeks
+
+### Changed
+
+## [0.0.2] - 2019-05-19
+
+- First release
+- Http `Client` added.
+- `MessageSerializer` added.
+- tests added
+- Documentation added

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -223,7 +223,7 @@ class SchemaRegistryClient:
             int: schema_id
         """
         schemas_to_id = self.subject_to_schema_ids[subject]
-        schema_id = schemas_to_id.get(avro_schema.name)
+        schema_id = schemas_to_id.get(avro_schema)
 
         if schema_id is not None:
             return schema_id

--- a/tests/client/test_schema.py
+++ b/tests/client/test_schema.py
@@ -74,5 +74,6 @@ def test_flat_schema(client):
     schema_version = client.get_schema(subject)
     parsed_schema = schema_version.schema
     parsed_schema.schema.pop("__fastavro_parsed")
+    parsed_schema.schema.pop("__named_schemas")
 
     assert schema_version.schema.flat_schema == parsed_schema.schema


### PR DESCRIPTION
subject_to _schema_ids maps subject -> schema -> schema_id, but this lookup is treated as a map subject -> subject -> schema_id, and so always misses, resulting in the registering of a new schema.